### PR TITLE
BUGFIX: Unable to setup a valve. getStateInt8() was parsing an already parsed object

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ SonoffAccessory.prototype.getStateInt8 = function(callback) {
   .end((error, response) => {
     if (!error && response.statusCode == 200) {
       var json = JSON.parse(response.text).data;
-      var state = JSON.parse(json).switch;
+      var state = json.switch;
 
       if (this.debug)           
           this.log('getState() request returned successfully ('+response.statusCode+'). Body: '+JSON.stringify(json));


### PR DESCRIPTION
## Plugin fails to retrieve data from a device configured as a valve. 
The function `getStateInt8` tries to parse the data included in `data` field as it was an stringified json but, the `data` field returned by the device is already an object so it is no need to parse again.

Function `getStateBool` already does this the right way

### Example data
`{
  "seq": 4,
  "error": 0,
  "data": {
    "switch": "off",
    "startup": "off",
    "pulse": "on",
    "pulseWidth": 500,
    "ssid": "REDACTED",
    "otaUnlock": false,
    "fwVersion": "3.6.0",
    "deviceid": "REDACTED",
    "bssid": "REDACTED",
    "signalStrength": -68
  }
}`




### Homebridge stacktrace
`[10/14/2024, 11:28:48 PM] SyntaxError: "[object Object]" is not valid JSON
    at JSON.parse (<anonymous>)
    at fn (/var/lib/homebridge/node_modules/homebridge-sonoff-mini-diy-rest/index.js:168:24)
    at Request.callback (/var/lib/homebridge/node_modules/homebridge-sonoff-mini-diy-rest/node_modules/superagent/src/node/index.js:890:12)
    at fn (/var/lib/homebridge/node_modules/homebridge-sonoff-mini-diy-rest/node_modules/superagent/src/node/index.js:1129:18)
    at IncomingMessage.<anonymous> (/var/lib/homebridge/node_modules/homebridge-sonoff-mini-diy-rest/node_modules/superagent/src/node/parsers/json.js:19:7)
    at IncomingMessage.emit (node:events:531:35)
    at endReadableNT (node:internal/streams/readable:1696:12)
    at processTicksAndRejections (node:internal/process/task_queues:82:21)`